### PR TITLE
Use brace expansion for computed prop dep keys

### DIFF
--- a/engineering/ember.md
+++ b/engineering/ember.md
@@ -1,11 +1,36 @@
 # Ember Style Guide
 
-## Test
+## Table Of Contents
+
+* [Computed Properties](#computed-properties)
+* [Tests](#tests)
+
+## Computed Properties
+
+### Use brace expansion
+
+This allows much less redundancy and is easier to read.
+
+Note that **the dependent keys must be together (without space)** for the brace expansion to work.
+
+```js
+// Good
+fullName: Ember.computed('user.{firstName,lastName}', {
+  // Code
+})
+
+// Bad
+fullName: Ember.computed('user.firstName', 'user.lastName', {
+  // Code
+})
+```
+
+## Tests
 
 ### [ember-test-selectors](https://github.com/simplabs/ember-test-selectors)
 
 Import using the following syntax.
 
-```javascript
+```js
 import testSelector from 'ember-test-selectors';
 ```


### PR DESCRIPTION
This allows much less redundancy and is easier to read.

Note that **the dependent keys must be together (without space)** for the brace expansion to work.

```js
// Good
fullName: Ember.computed('user.{firstName,lastName}', {
  // Code
})

// Bad
fullName: Ember.computed('user.firstName', 'user.lastName', {
  // Code
})
```