### PR TITLE
Don't use partials in templates

### DIFF
--- a/engineering/ember.md
+++ b/engineering/ember.md
@@ -3,6 +3,7 @@
 ## Table Of Contents
 
 * [Computed Properties](#computed-properties)
+* [Templates](#templates)
 * [Tests](#tests)
 
 ## Computed Properties
@@ -24,6 +25,17 @@ fullName: Ember.computed('user.firstName', 'user.lastName', {
   // Code
 })
 ```
+
+## Templates
+
+### Don't use partials
+
+Use components instead of partials.
+
+Partials have access to properties in their parent template's scope while
+components require any external properties used to be explicitly passed in. This
+prevents difficult to diagnose bugs, provides more confidence when
+refactoring. Components are also easier to test.
 
 ## Tests
 


### PR DESCRIPTION
Use components instead of partials.

Partials have access to properties in their parent template's scope while
components require any external properties used to be explicitly passed in. This
prevents difficult to diagnose bugs and provides more confidence when
refactoring. Components are also easier to test.
